### PR TITLE
Fix for hidden pronoun dropdown bug

### DIFF
--- a/src/screens/Profile/Edit.js
+++ b/src/screens/Profile/Edit.js
@@ -233,7 +233,7 @@ export default function edit({ route, navigation }) {
                             />
                         </View>
 
-                        <View style={styles.row}>
+                        <View style={{...styles.row, zIndex: 1}}>
                             <TextInput
                                 keyboardType="numeric"
                                 placeholder="Birth year"

--- a/src/screens/auth/Registration/Name.js
+++ b/src/screens/auth/Registration/Name.js
@@ -132,7 +132,7 @@ const Name = props => {
                 />
               </View>
 
-              <View style={styles.row}>
+              <View style={{...styles.row, zIndex: 1}}>
                 <TextInput
                   placeholder="Birth year"
                   value={age}


### PR DESCRIPTION
Gave the dropdown container a higher index so that it takes screen space precedence over the other things (i.e., the text and the fun facts).

Couldn't test on Android since my Android emulator is broken now :(

![IMG_5011](https://github.com/eat-together-team/eat-together/assets/51427024/c4edd687-194b-4c54-981f-7faf4b71af34)
