### PR TITLE
Photo gallery ios modal stacking fix

### DIFF
--- a/src/screens/Home/EventGallery.js
+++ b/src/screens/Home/EventGallery.js
@@ -310,8 +310,8 @@ export default function EventGallery({ route, navigation }) {
                 <View style={styles.modalBottom}> 
                     {/* Image Information */}
                     <View style ={{flexDirection: "row", padding:10, alignItems:"center",justifyContent: "center",}}>
-                        <Filter checked={false} onPress={() => getMetadata(selectedImageUri)} text="  Info  "  />
-                        <Filter checked={false} onPress={() => handleDeleteImage(selectedImageUri)} text="  Delete  " />
+                        <Filter checked={false} onPress={() => getMetadata(selectedImageUri)} text="Info"  />
+                        <Filter checked={false} onPress={() => handleDeleteImage(selectedImageUri)} text="Delete" />
                     </View>
                 </View>
             </Modal>

--- a/src/screens/Home/Gallery.js
+++ b/src/screens/Home/Gallery.js
@@ -382,6 +382,7 @@ export default function Gallery({ route, navigation }) {
     };
 
     const handleAssignEvent = (uri) => {
+        setIsModalVisible(false);
         setSelectedImageForEvent(uri);
         setIsEventModalVisible(true);
     };
@@ -624,8 +625,8 @@ export default function Gallery({ route, navigation }) {
                 </TouchableWithoutFeedback>
                 <View style={styles.modalBottom}>
                     <View style ={{flexDirection: "row", padding:10, alignItems:"center",justifyContent: "center",}}>
-                        <Filter checked={false} onPress={() => getMetadata(selectedImageUri)} text="  Info  "  />
-                        <Filter checked={false} onPress={() => handleDeleteImage(selectedImageUri)} text="  Delete  " />
+                        <Filter checked={false} onPress={() => getMetadata(selectedImageUri)} text="Info"  />
+                        <Filter checked={false} onPress={() => handleDeleteImage(selectedImageUri)} text="Delete" />
                     </View>
                     <View style={styles.assignBottom}> 
                         <Button backgroundColor="white" color="#5DB075" onPress={() => handleAssignEvent(selectedImageUri)}>Assign Image</Button>


### PR DESCRIPTION
Author: Navneeth Dhamotharan

## What changes were made?
1. Fixed ios double modal stacking issue.
2.  removed whitespace for the info and delete buttons as ios does not count trailing whitespace.


## Why are these changes important/necessary?
 to ensure that the assign image to event picker can show up on ios devices

## (If applicable) Screenshots of your changes. Providing an “old vs. new” comparison would be great!

