### PR TITLE
Bug Fix: gallery hangs on loading when you exit caption modal prematurely

### DIFF
--- a/src/screens/Home/EventGallery.js
+++ b/src/screens/Home/EventGallery.js
@@ -389,7 +389,7 @@ export default function EventGallery({ route, navigation }) {
                 </View>
             </Modal>
             <Modal visible={isCaptionModalVisible} transparent={true} onRequestClose={() => setIsCaptionModalVisible(false)}>
-                <TouchableWithoutFeedback onPress={() => {setIsCaptionModalVisible(false),setLoading(false);}}>
+                <TouchableWithoutFeedback onPress={() => {setIsCaptionModalVisible(false),setLoading(false)}}>
                     <View style={modalStyles.modalBackground}>
                         <View style={modalStyles.modalContainer}>
                             <View style={modalStyles.captionItem}>

--- a/src/screens/Home/Gallery.js
+++ b/src/screens/Home/Gallery.js
@@ -670,7 +670,7 @@ export default function Gallery({ route, navigation }) {
                 </TouchableWithoutFeedback>
             </Modal>
             <Modal visible={isCaptionModalVisible} transparent={true} onRequestClose={() => setIsCaptionModalVisible(false)}>
-                <TouchableWithoutFeedback onPress={() => {setIsCaptionModalVisible(false),setLoading(false);}}>
+                <TouchableWithoutFeedback onPress={() => {setIsCaptionModalVisible(false),setLoading(false)}}>
                     <View style={modalStyles.modalBackground}>
                         <View style={modalStyles.modalContainer}>
                             <View>


### PR DESCRIPTION
Author: Navneeth Dhamotharan

## What changes were made?
 Fixed the bug where the gallery hangs on loading after you prematurely exit the caption modal prematurely.
Also changed the Add/Edit button to Add | Edit so that the division between the words looks less cramped
## Why are these changes important/necessary?
The ensure seamless usage of the app.

## (If applicable) Screenshots of your changes. Providing an “old vs. new” comparison would be great!

Old Version of the Add/Edit
![image](https://github.com/user-attachments/assets/b241ea92-2cb9-45ad-a3eb-88344c9f2ca6)
New Version of the Add | Edit
![image](https://github.com/user-attachments/assets/8ad9654f-c6ce-4dea-ae2e-f59a04f5cd92)